### PR TITLE
Fix CRAM-MD5 server challenge to store the encoded challenge string

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -6,7 +6,7 @@ jobs:
     name: Code Analysis
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -17,17 +17,17 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Install Composer Dependencies
-        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer Dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Run Test Coverage
         run: composer run-script test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -22,17 +22,18 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Install Composer dependencies
-        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Run Unit Tests
         run: composer run-script test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+0.2.0 (2026-03-22)
+------------------
+* Fix CRAM-MD5 server challenge to store the encoded challenge string (e.g. `<nonce>`) in the SASL context rather than the raw nonce, so the password callable receives the value the client used for its HMAC per RFC 2195.
+
 0.1.1 (2019-12-09)
 ------------------
 * Add an option to set the host section of the digest-uri for DIGEST-MD5. Mostly for easier AD support.

--- a/src/FreeDSx/Sasl/Challenge/CramMD5Challenge.php
+++ b/src/FreeDSx/Sasl/Challenge/CramMD5Challenge.php
@@ -70,8 +70,12 @@ class CramMD5Challenge implements ChallengeInterface
     {
         $nonce = $options['challenge'] ?? $this->generateNonce(32);
         $challenge = new Message(['challenge' => $nonce]);
-        $this->context->setResponse($this->encoder->encode($challenge, $this->context));
-        $this->context->set('challenge', $challenge->get('challenge'));
+        $encoded = $this->encoder->encode($challenge, $this->context);
+        $this->context->setResponse($encoded);
+        // Store the encoded challenge string (e.g. "<nonce>") rather than the raw nonce.
+        // RFC 2195 requires the HMAC to be computed over the challenge exactly as the client
+        // received it, so the value passed to the password callable must match the encoded form.
+        $this->context->set('challenge', $encoded);
 
         return $this->context;
     }

--- a/tests/unit/FreeDSx/Sasl/Challenge/CramMD5ChallengeTest.php
+++ b/tests/unit/FreeDSx/Sasl/Challenge/CramMD5ChallengeTest.php
@@ -61,11 +61,59 @@ class CramMD5ChallengeTest extends TestCase
         $validate = function (string $username, string $challenge) {
             return hash_hmac('md5', $challenge, 'bar');
         };
-        $this->challenge->challenge(null, ['challenge' => '<foobar>']);
+        // The challenge option is the raw nonce; the encoder wraps it as <foobar>.
+        $this->challenge->challenge(null, ['challenge' => 'foobar']);
         $context = $this->challenge->challenge('foo e23c893e9de272d4a75e646265768a45', ['password' => $validate]);
 
         $this->assertTrue($context->isAuthenticated());
         $this->assertTrue($context->isComplete());
+    }
+
+    public function testPasswordCallableReceivesEncodedChallengeMatchingWhatClientUses(): void
+    {
+        $this->challenge = new CramMD5Challenge(true);
+
+        $challengePassedToCallable = null;
+        $validate = function (string $username, string $challenge) use (&$challengePassedToCallable) {
+            $challengePassedToCallable = $challenge;
+
+            return hash_hmac(
+                'md5',
+                $challenge,
+                'bar'
+            );
+        };
+
+        // Server generates challenge with raw nonce 'foobar'; encoder sends '<foobar>' to client.
+        $serverContext = $this->challenge->challenge(
+            null,
+            ['challenge' => 'foobar']
+        );
+        $encodedChallenge = $serverContext->getResponse();
+        $this->assertSame(
+            '<foobar>',
+            $encodedChallenge
+        );
+
+        // Client computes HMAC over the encoded challenge exactly as received.
+        $clientChallenge = new CramMD5Challenge(false);
+        $clientContext = $clientChallenge->challenge(
+            $encodedChallenge,
+            ['username' => 'foo', 'password' => 'bar']
+        );
+
+        // Server validates the client response.
+        $this->challenge->challenge(
+            $clientContext->getResponse(),
+            ['password' => $validate]
+        );
+
+        // The callable must receive the encoded form so it can compute the same digest as the client.
+        $this->assertSame(
+            '<foobar>',
+            $challengePassedToCallable
+        );
+        $this->assertTrue($this->challenge->challenge()->isAuthenticated());
     }
 
     public function testChallengeWithFromServerWithInitialChallenge()


### PR DESCRIPTION
Fixing an issue discovered in the CRAM-MD5 server challenge I discovered while implementing it in the LDAP library.