### PR TITLE
Add the SCRAM mechanism.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 0.2.0 (2026-03-22)
 ------------------
 * Fix CRAM-MD5 server challenge to store the encoded challenge string (e.g. `<nonce>`) in the SASL context rather than the raw nonce, so the password callable receives the value the client used for its HMAC per RFC 2195.
+* Add SCRAM support (RFC 5802 / RFC 7677) covering all standard variants: SCRAM-SHA-1, SCRAM-SHA-224, SCRAM-SHA-256, SCRAM-SHA-384, SCRAM-SHA-512, SCRAM-SHA3-512, and their respective `-PLUS` channel-binding counterparts.
 
 0.1.1 (2019-12-09)
 ------------------

--- a/docs/Mechanisms.md
+++ b/docs/Mechanisms.md
@@ -1,0 +1,241 @@
+# SASL Mechanisms
+
+This library provides the following SASL mechanisms. All mechanisms are registered by default; use the `supported` option to restrict which are available.
+
+```php
+use FreeDSx\Sasl\Sasl;
+
+$sasl = new Sasl();
+
+// Restrict to specific mechanisms
+$sasl = new Sasl(['supported' => ['SCRAM-SHA-256', 'PLAIN']]);
+
+// Get a specific mechanism
+$mechanism = $sasl->get('SCRAM-SHA-256');
+
+// Select the best mechanism from a server-advertised list
+$mechanism = $sasl->select(['SCRAM-SHA-256', 'PLAIN', 'DIGEST-MD5']);
+```
+
+---
+
+## ANONYMOUS
+
+No authentication. Sends optional trace information to the server.
+
+**Security:** No integrity, no privacy, no authentication.
+
+**Client options:**
+
+| Option     | Default | Description                              |
+|------------|---------|------------------------------------------|
+| `username` | `null`  | Optional trace string sent to the server |
+
+```php
+$challenge = $mechanism->challenge();
+
+$response = $challenge->challenge(
+    null,
+    ['username' => 'guest@example.com']
+);
+
+// $response->isComplete() === true after one round
+```
+
+---
+
+## PLAIN
+
+Sends credentials as plaintext. Use only over TLS.
+
+**Security:** Authenticates but transmits password in plaintext.
+
+**Client options:**
+
+| Option     | Default      | Description             |
+|------------|--------------|-------------------------|
+| `username` | *(required)* | Authentication identity |
+| `password` | *(required)* | User password           |
+
+**Server options:**
+
+| Option     | Default      | Description                                                          |
+|------------|--------------|----------------------------------------------------------------------|
+| `validate` | *(required)* | `callable(string $authzid, string $authcid, string $password): bool` |
+
+```php
+// Client
+$response = $challenge->challenge(null, [
+    'username' => 'user',
+    'password' => 'secret',
+]);
+
+// Server
+$response = $challenge->challenge($received, [
+    'validate' => fn($authzid, $authcid, $password) => $password === getPassword($authcid),
+]);
+```
+
+---
+
+## CRAM-MD5
+
+Server sends a challenge; a client responds with an HMAC-MD5 digest. Two-round exchange.
+
+**Security:** Authenticates without transmitting the password in plaintext.
+
+**Client options:**
+
+| Option     | Default      | Description   |
+|------------|--------------|---------------|
+| `username` | *(required)* | Username      |
+| `password` | *(required)* | User password |
+
+**Server options:**
+
+| Option      | Default              | Description                                                                       |
+|-------------|----------------------|-----------------------------------------------------------------------------------|
+| `challenge` | random 32-byte nonce | Override the server challenge string                                              |
+| `password`  | *(required)*         | `callable(string $username, string $challenge): string` — returns expected digest |
+
+```php
+// Client (round 1: receive challenge, round 2: send response)
+$response = $challenge->challenge($serverChallenge, [
+    'username' => 'user',
+    'password' => 'secret',
+]);
+```
+
+---
+
+## DIGEST-MD5
+
+Multi-round MD5-based authentication with optional integrity and privacy security layers. Implements RFC 2831.
+
+**Security:** Authenticates without plaintext password. Optionally provides integrity (`auth-int`) or privacy (`auth-conf`) security layers.
+
+**Client options:**
+
+| Option          | Default      | Description                                       |
+|-----------------|--------------|---------------------------------------------------|
+| `username`      | *(required)* | Username                                          |
+| `password`      | *(required)* | User password                                     |
+| `host`          | `null`       | Hostname for the digest-uri                       |
+| `realm`         | `null`       | Authentication realm                              |
+| `use_integrity` | `false`      | Enable integrity layer (`qop=auth-int`)           |
+| `use_privacy`   | `false`      | Enable privacy/encryption layer (`qop=auth-conf`) |
+| `service`       | `'ldap'`     | SASL service name                                 |
+| `cnonce`        | random       | Client nonce                                      |
+| `cipher`        | auto         | Cipher for privacy (e.g. `'rc4'`, `'3des'`)       |
+
+**Server options:**
+
+| Option          | Default      | Description                              |
+|-----------------|--------------|------------------------------------------|
+| `validate`      | *(required)* | Callable to validate the client response |
+| `use_integrity` | `false`      | Offer integrity layer                    |
+| `use_privacy`   | `false`      | Offer privacy layer                      |
+| `service`       | `'ldap'`     | SASL service name                        |
+| `nonce`         | random       | Override the server nonce                |
+
+```php
+$response = $challenge->challenge($serverMessage, [
+    'username' => 'user',
+    'password' => 'secret',
+    'host'     => 'ldap.example.com',
+    'service'  => 'ldap',
+]);
+```
+
+---
+
+## SCRAM-SHA-* (RFC 5802 / RFC 7677)
+
+Modern salted challenge-response mechanisms using PBKDF2 key derivation and HMAC signatures. Mutual authentication: the client also verifies the server. `-PLUS` variants add TLS channel binding.
+
+**Available mechanisms:**
+
+| Mechanism             | Hash Algorithm | Channel Binding |
+|-----------------------|----------------|-----------------|
+| `SCRAM-SHA-1`         | SHA-1          | No              |
+| `SCRAM-SHA-1-PLUS`    | SHA-1          | Yes             |
+| `SCRAM-SHA-224`       | SHA-224        | No              |
+| `SCRAM-SHA-224-PLUS`  | SHA-224        | Yes             |
+| `SCRAM-SHA-256`       | SHA-256        | No              |
+| `SCRAM-SHA-256-PLUS`  | SHA-256        | Yes             |
+| `SCRAM-SHA-384`       | SHA-384        | No              |
+| `SCRAM-SHA-384-PLUS`  | SHA-384        | Yes             |
+| `SCRAM-SHA-512`       | SHA-512        | No              |
+| `SCRAM-SHA-512-PLUS`  | SHA-512        | Yes             |
+| `SCRAM-SHA3-512`      | SHA3-512       | No              |
+| `SCRAM-SHA3-512-PLUS` | SHA3-512       | Yes             |
+
+**Security:** Authenticates without transmitting the password. Resistant to replay and server-impersonation attacks. Use `-PLUS` variants with TLS channel binding for the strongest guarantee.
+
+### Client options
+
+**Round 1 (client-first):**
+
+| Option       | Default         | Description                                     |
+|--------------|-----------------|-------------------------------------------------|
+| `username`   | *(required)*    | Username (`=` and `,` are encoded per RFC 5802) |
+| `cnonce`     | 24 random bytes | Client nonce                                    |
+| `cbind_type` | `'tls-unique'`  | Channel binding type (for `-PLUS` variants)     |
+
+**Round 2 (client-final):**
+
+| Option       | Default      | Description                                     |
+|--------------|--------------|-------------------------------------------------|
+| `password`   | *(required)* | User password                                   |
+| `cbind_data` | `''`         | Raw channel binding data (for `-PLUS` variants) |
+
+### Server options
+
+**Round 1 (server-first):**
+
+| Option       | Default         | Description                          |
+|--------------|-----------------|--------------------------------------|
+| `nonce`      | 24 random bytes | Server portion of the combined nonce |
+| `salt`       | 16 random bytes | PBKDF2 salt (raw binary)             |
+| `iterations` | `4096`          | PBKDF2 iteration count               |
+
+**Round 2 (server-final):**
+
+| Option     | Default      | Description                              |
+|------------|--------------|------------------------------------------|
+| `password` | *(required)* | User password to verify the client proof |
+
+### Example (client)
+
+```php
+$mechanism = $sasl->get('SCRAM-SHA-256');
+$challenge = $mechanism->challenge();
+
+// Round 1: send client-first message
+$response = $challenge->challenge(null, ['username' => 'user']);
+$clientFirst = $response->get('response');
+
+// Round 2: receive server-first, send client-final with password
+$response = $challenge->challenge($serverFirst, ['password' => 'secret']);
+$clientFinal = $response->get('response');
+
+// Round 3: receive server-final, verify server signature
+$response = $challenge->challenge($serverFinal, []);
+// $response->isComplete() === true
+```
+
+---
+
+## Security Strength Summary
+
+| Mechanism   | Authentication | Integrity Layer | Privacy Layer | Plaintext Password |
+|-------------|:--------------:|:---------------:|:-------------:|:------------------:|
+| ANONYMOUS   |       No       |       No        |      No       |         No         |
+| PLAIN       |      Yes       |       No        |      No       |      **Yes**       |
+| CRAM-MD5    |      Yes       |       No        |      No       |         No         |
+| DIGEST-MD5  |      Yes       |    Optional     |   Optional    |         No         |
+| SCRAM-SHA-* |  Yes (mutual)  |       No        |      No       |         No         |
+
+For new integrations, prefer `SCRAM-SHA-256` or higher over `PLAIN`, `CRAM-MD5`, and `DIGEST-MD5`.
+
+Always use SCRAM or PLAIN over a TLS-protected connection.

--- a/src/FreeDSx/Sasl/Challenge/ScramChallenge.php
+++ b/src/FreeDSx/Sasl/Challenge/ScramChallenge.php
@@ -1,0 +1,693 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Sasl\Challenge;
+
+use FreeDSx\Sasl\Encoder\ScramEncoder;
+use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\Factory\NonceTrait;
+use FreeDSx\Sasl\Message;
+use FreeDSx\Sasl\SaslContext;
+use FreeDSx\Sasl\SaslPrep;
+
+/**
+ * The SCRAM challenge / response class (RFC 5802).
+ *
+ * Handles all SCRAM hash variants (SHA-1, SHA-256, SHA-512, etc.) and both standard
+ * and channel-binding (-PLUS) variants. The hash algorithm is provided at construction
+ * time using the PHP hash algorithm name (e.g. 'sha256', 'sha1', 'sha3-512').
+ *
+ * Client flow (client-first):
+ *   1. challenge(null, options)          -> client-first-message
+ *   2. challenge(server-first, options)  -> client-final-message (with proof)
+ *   3. challenge(server-final, options)  -> null (verifies server signature, sets isAuthenticated)
+ *
+ * Server flow:
+ *   1. challenge(null, options)          -> null (SCRAM is client-initiated)
+ *   2. challenge(client-first, options)  -> server-first-message
+ *   3. challenge(client-final, options)  -> server-final-message (v= or e=)
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class ScramChallenge implements ChallengeInterface
+{
+    use NonceTrait;
+
+    /**
+     * Default nonce size in bytes. Produces ~32 base64 characters; well above the RFC 5802 minimum.
+     */
+    private const NONCE_SIZE = 24;
+
+    private const ALGO_SHA1 = 'sha1';
+
+    private const ALGO_SHA224 = 'sha224';
+
+    private const ALGO_SHA256 = 'sha256';
+
+    private const ALGO_SHA384 = 'sha384';
+
+    private const ALGO_SHA512 = 'sha512';
+
+    private const ALGO_SHA3_512 = 'sha3-512';
+
+    /**
+     * PHP hash algorithm names supported by this class.
+     */
+    private const SUPPORTED_ALGORITHMS = [
+        self::ALGO_SHA1,
+        self::ALGO_SHA224,
+        self::ALGO_SHA256,
+        self::ALGO_SHA384,
+        self::ALGO_SHA512,
+        self::ALGO_SHA3_512,
+    ];
+
+    /**
+     * Minimum PBKDF2 iteration count the client will accept from a server, keyed by PHP hash algorithm name.
+     * Values follow RFC 5802 (SHA-1: 4096) and RFC 7677 (SHA-256: 4096).
+     */
+    private const MIN_ITERATIONS = [
+        self::ALGO_SHA1     => 4096,
+        self::ALGO_SHA224   => 4096,
+        self::ALGO_SHA256   => 4096,
+        self::ALGO_SHA384   => 4096,
+        self::ALGO_SHA512   => 4096,
+        self::ALGO_SHA3_512 => 4096,
+    ];
+
+    /**
+     * Maximum PBKDF2 iteration count accepted from a server (or configured for a server).
+     * OWASP 2024 recommends 600,000 for SHA-256 as a minimum; values above 1,000,000 are
+     * unlikely to reflect a legitimate security policy and risk client-side DoS.
+     */
+    private const MAX_ITERATIONS = 1000000;
+
+    /**
+     * Default PBKDF2 iteration count used when the server generates a challenge, keyed by PHP hash
+     * algorithm name. Values are based on RFC 8265 guidance (≥15,000 for SHA-256) and scaled
+     * conservatively for stronger hash variants.
+     */
+    private const DEFAULT_ITERATIONS = [
+        self::ALGO_SHA1     => 10000,
+        self::ALGO_SHA224   => 15000,
+        self::ALGO_SHA256   => 15000,
+        self::ALGO_SHA384   => 10000,
+        self::ALGO_SHA512   => 10000,
+        self::ALGO_SHA3_512 => 10000,
+    ];
+
+    private const HMAC_CLIENT_KEY = 'Client Key';
+
+    private const HMAC_SERVER_KEY = 'Server Key';
+
+    private const CTX_GS2_HEADER = 'scram-gs2-header';
+
+    private const CTX_CNONCE = 'scram-cnonce';
+
+    private const CTX_CLIENT_FIRST_BARE = 'scram-client-first-bare';
+
+    private const CTX_SERVER_SIGNATURE  = 'scram-server-signature';
+
+    private const CTX_NONCE = 'scram-nonce';
+
+    private const CTX_SALT = 'scram-salt';
+
+    private const CTX_ITERATIONS = 'scram-iterations';
+
+    private const CTX_SERVER_FIRST = 'scram-server-first';
+
+    private const INVALID_PROOF = 'e=invalid-proof';
+
+    /**
+     * @var SaslContext
+     */
+    private $context;
+
+    /**
+     * @var ScramEncoder
+     */
+    private $encoder;
+
+    /**
+     * PHP hash algorithm name (e.g. 'sha256', 'sha1', 'sha3-512').
+     *
+     * @var string
+     */
+    private $hashAlgorithm;
+
+    /**
+     * Whether this is a channel-binding (-PLUS) variant.
+     *
+     * @var bool
+     */
+    private $isChannelBinding;
+
+    /**
+     * @throws SaslException
+     */
+    public function __construct(
+        bool $isServerMode = false,
+        string $hashAlgorithm = 'sha256',
+        bool $isChannelBinding = false
+    ) {
+        if (!in_array($hashAlgorithm, self::SUPPORTED_ALGORITHMS, true)) {
+            throw new SaslException(sprintf(
+                'The hash algorithm "%s" is not supported. Supported algorithms: %s.',
+                $hashAlgorithm,
+                implode(', ', self::SUPPORTED_ALGORITHMS)
+            ));
+        }
+
+        $this->hashAlgorithm = $hashAlgorithm;
+        $this->isChannelBinding = $isChannelBinding;
+        $this->encoder = new ScramEncoder();
+        $this->context = new SaslContext();
+        $this->context->setIsServerMode($isServerMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function challenge(
+        ?string $received = null,
+        array $options = []
+    ): SaslContext {
+        # Keep the raw received string for auth-message construction before decoding.
+        $rawReceived = $received;
+        $received = $received !== null ? $this->encoder->decode($received, $this->context) : null;
+
+        if ($this->context->isServerMode()) {
+            $response = $this->generateServerResponse($received, $rawReceived, $options);
+        } else {
+            $response = $this->generateClientResponse($received, $rawReceived, $options);
+        }
+
+        $this->context->setResponse($response);
+
+        return $this->context;
+    }
+
+    /**
+     * @throws SaslException
+     */
+    private function generateClientResponse(
+        ?Message $received,
+        ?string $rawReceived,
+        array $options
+    ): ?string {
+        # Step 1: No message yet — generate client-first-message.
+        if ($received === null) {
+            return $this->generateClientFirst($options);
+        }
+
+        # Step 2: Server-first-message received (contains 's' and 'i') — generate client-final-message.
+        if ($received->has('s') && $received->has('i')) {
+            return $this->generateClientFinal($received, (string) $rawReceived, $options);
+        }
+
+        # Step 3: Server-final-message received (contains 'v' or 'e') — verify and complete.
+        if ($received->has('v') || $received->has('e')) {
+            $this->verifyServerFinal($received);
+
+            return null;
+        }
+
+        throw new SaslException('Unexpected SCRAM message received on the client.');
+    }
+
+    /**
+     * @throws SaslException
+     */
+    private function generateServerResponse(
+        ?Message $received,
+        ?string $rawReceived,
+        array $options
+    ): ?string {
+        # SCRAM is client-initiated — the server has no opening message.
+        if ($received === null) {
+            return null;
+        }
+
+        # Step 1: Client-first-message received (contains 'n' and 'r', no proof yet).
+        if ($received->has('n') && $received->has('r') && !$received->has('p')) {
+            return $this->generateServerFirst($received, (string) $rawReceived, $options);
+        }
+
+        # Step 2: Client-final-message received (contains channel binding 'c' and proof 'p').
+        if ($received->has('c') && $received->has('p')) {
+            return $this->generateServerFinal(
+                $received,
+                $options
+            );
+        }
+
+        throw new SaslException('Unexpected SCRAM message received on the server.');
+    }
+
+    /**
+     * Generates the client-first-message: GS2-header + client-first-message-bare.
+     *
+     *   client-first-message = gs2-header client-first-message-bare
+     *   client-first-message-bare = [reserved-mext ","] n=username "," r=nonce
+     *
+     * @param array{username?: string, cnonce?: string, cbind_type?: string} $options
+     *
+     * @throws SaslException
+     */
+    private function generateClientFirst(array $options): string
+    {
+        $username = $options['username'] ?? null;
+        if ($username === null) {
+            throw new SaslException('A username is required to initiate SCRAM authentication.');
+        }
+
+        $cnonce = $options['cnonce'] ?? $this->generateNonce(self::NONCE_SIZE);
+        if ($cnonce === '') {
+            throw new SaslException('The client nonce must not be empty.');
+        }
+
+        if ($this->isChannelBinding) {
+            $cbindType = $options['cbind_type'] ?? 'tls-unique';
+            $this->validateCbindType($cbindType);
+            $gs2Header = 'p=' . $cbindType . ',,';
+        } else {
+            $gs2Header = 'n,,';
+        }
+
+        # RFC 5802 §2: apply SASLprep before encoding the username.
+        $username = SaslPrep::prepare($username);
+
+        # RFC 5802 section 5.1: '=' and ',' in the username must be encoded.
+        $username = str_replace(
+            ['=', ','],
+            ['=3D', '=2C'],
+            $username
+        );
+
+        $clientFirstBare = 'n=' . $username . ',r=' . $cnonce;
+
+        $this->context->set(self::CTX_GS2_HEADER, $gs2Header);
+        $this->context->set(self::CTX_CNONCE, $cnonce);
+        $this->context->set(self::CTX_CLIENT_FIRST_BARE, $clientFirstBare);
+
+        return $gs2Header . $clientFirstBare;
+    }
+
+    /**
+     * Generates the client-final-message from the received server-first-message.
+     *
+     *   client-final-message = client-final-message-without-proof "," p=client-proof
+     *   client-final-message-without-proof = "c=" base64 "," r=nonce
+     *
+     * @param array{password?: string, cbind_data?: string} $options
+     *
+     * @throws SaslException
+     */
+    private function generateClientFinal(
+        Message $serverFirst,
+        string $rawServerFirst,
+        array $options
+    ): string {
+        $password = $options['password'] ?? null;
+        if ($password === null) {
+            throw new SaslException('A password is required to complete SCRAM authentication.');
+        }
+
+        # Guard against out-of-order calls: client-first must have run first to populate the cnonce.
+        $cnonce = $this->context->get(self::CTX_CNONCE);
+        if ($cnonce === null) {
+            throw new SaslException(
+                'client-final called before client-first: no client nonce found in context.'
+            );
+        }
+        $cnonce = (string) $cnonce;
+
+        # The full nonce must begin with the client nonce we sent — verify before processing anything else.
+        [$fullNonce, $salt, $iterations] = $this->parseServerFirst($serverFirst, $cnonce);
+
+        # Channel binding value: base64(gs2-header + cbind-data).
+        $gs2Header = (string) $this->context->get(self::CTX_GS2_HEADER);
+        $cbindData = $options['cbind_data'] ?? '';
+        $channelBinding = base64_encode($gs2Header . $cbindData);
+
+        $clientFinalWithoutProof = 'c=' . $channelBinding . ',r=' . $fullNonce;
+
+        # RFC 5802 section 3: AuthMessage = client-first-bare "," server-first "," client-final-without-proof
+        $authMessage = $this->context->get(self::CTX_CLIENT_FIRST_BARE)
+            . ',' . $rawServerFirst
+            . ',' . $clientFinalWithoutProof;
+
+        $saltedPassword = $this->deriveSaltedPassword((string) $password, $salt, $iterations);
+        $clientProof = $this->makeClientProof(
+            $saltedPassword,
+            $authMessage
+        );
+
+        # Pre-compute the expected server signature so we can verify it in step 3.
+        $serverKey = $this->hmac(
+            $saltedPassword,
+            self::HMAC_SERVER_KEY
+        );
+        $serverSignature = $this->hmac(
+            $serverKey,
+            $authMessage
+        );
+        $this->context->set(
+            self::CTX_SERVER_SIGNATURE,
+            base64_encode($serverSignature)
+        );
+
+        return $clientFinalWithoutProof . ',p=' . base64_encode($clientProof);
+    }
+
+    /**
+     * Verifies the server-final-message and marks authentication as complete.
+     *
+     * @throws SaslException
+     */
+    private function verifyServerFinal(Message $serverFinal): void
+    {
+        $this->context->setIsComplete(true);
+
+        if ($serverFinal->has('e')) {
+            throw new SaslException(sprintf(
+                'SCRAM authentication failed with server error: %s',
+                $serverFinal->get('e')
+            ));
+        }
+
+        $expectedSig = (string) $this->context->get(self::CTX_SERVER_SIGNATURE);
+        $receivedSig = (string) $serverFinal->get('v');
+
+        if (!hash_equals($expectedSig, $receivedSig)) {
+            throw new SaslException('The server signature does not match the expected value.');
+        }
+
+        $this->context->setIsAuthenticated(true);
+    }
+
+    /**
+     * Generates the server-first-message in response to the client-first-message.
+     *
+     *   server-first-message = [reserved-mext ","] r=nonce "," s=salt "," i=iteration-count
+     *
+     * @param array{nonce?: string, salt?: string, iterations?: int} $options
+     *
+     * @throws SaslException
+     */
+    private function generateServerFirst(
+        Message $clientFirst,
+        string $rawClientFirst,
+        array $options
+    ): string {
+        $cnonce = (string) $clientFirst->get('r');
+        $snonce = $options['nonce'] ?? $this->generateNonce(self::NONCE_SIZE);
+        $fullNonce = $cnonce . $snonce;
+
+        $salt = $options['salt'] ?? random_bytes(16);
+        $iterations = (int) ($options['iterations'] ?? self::DEFAULT_ITERATIONS[$this->hashAlgorithm]);
+        if ($iterations < 1) {
+            throw new SaslException('The iteration count must be greater than zero.');
+        }
+        if ($iterations > self::MAX_ITERATIONS) {
+            throw new SaslException(sprintf(
+                'The iteration count of %d exceeds the maximum allowed of %d.',
+                $iterations,
+                self::MAX_ITERATIONS
+            ));
+        }
+
+        $clientFirstBare = $this->extractClientFirstBare($rawClientFirst);
+        $serverFirst = 'r=' . $fullNonce . ',s=' . base64_encode($salt) . ',i=' . $iterations;
+
+        $this->context->set(self::CTX_CLIENT_FIRST_BARE, $clientFirstBare);
+        $this->context->set(self::CTX_NONCE, $fullNonce);
+        $this->context->set(self::CTX_SALT, $salt);
+        $this->context->set(self::CTX_ITERATIONS, $iterations);
+        $this->context->set(self::CTX_SERVER_FIRST, $serverFirst);
+
+        return $serverFirst;
+    }
+
+    /**
+     * Verifies the client-final-message and generates the server-final-message.
+     *
+     * Returns 'v=<server-signature>' on success, or 'e=<error>' on failure.
+     *
+     * @param array{password?: string} $options
+     *
+     * @throws SaslException
+     */
+    private function generateServerFinal(
+        Message $clientFinal,
+        array $options
+    ): string {
+        $this->context->setIsComplete(true);
+
+        $password = $options['password'] ?? null;
+        if ($password === null) {
+            return self::INVALID_PROOF;
+        }
+
+        $fullNonce = (string) $this->context->get(self::CTX_NONCE);
+        if ($clientFinal->get('r') !== $fullNonce) {
+            return self::INVALID_PROOF;
+        }
+
+        $salt = (string) $this->context->get(self::CTX_SALT);
+        $iterations = (int) $this->context->get(self::CTX_ITERATIONS);
+
+        # Reconstruct client-final-without-proof for the auth message.
+        # RFC 5802: the order is fixed as c=...,r=...[,extensions] so we can rebuild it safely.
+        $clientFinalWithoutProof = 'c=' . $clientFinal->get('c') . ',r=' . $clientFinal->get('r');
+        $authMessage = $this->context->get(self::CTX_CLIENT_FIRST_BARE)
+            . ',' . $this->context->get(self::CTX_SERVER_FIRST)
+            . ',' . $clientFinalWithoutProof;
+
+        try {
+            $saltedPassword = $this->deriveSaltedPassword(
+                (string) $password,
+                $salt,
+                $iterations
+            );
+        } catch (SaslException $e) {
+            return self::INVALID_PROOF;
+        }
+
+        if (!$this->isValidClientProof($clientFinal, $saltedPassword, $authMessage)) {
+            return self::INVALID_PROOF;
+        }
+
+        $serverKey = $this->hmac($saltedPassword, self::HMAC_SERVER_KEY);
+        $serverSignature = $this->hmac($serverKey, $authMessage);
+
+        $this->context->setIsAuthenticated(true);
+
+        return 'v=' . base64_encode($serverSignature);
+    }
+
+    /**
+     * Strips the GS2 header from the client-first-message, returning only the bare portion.
+     *
+     * GS2 header formats end with ',,': 'n,,', 'y,,', or 'p=type,,'.
+     *
+     * @throws SaslException
+     */
+    private function extractClientFirstBare(string $clientFirst): string
+    {
+        $pos = strpos(
+            $clientFirst,
+            ',,'
+        );
+        if ($pos === false) {
+            throw new SaslException('Unable to parse GS2 header from client-first-message.');
+        }
+
+        return substr(
+            $clientFirst,
+            $pos + 2
+        );
+    }
+
+    /**
+     * Validates and parses the server-first-message fields needed by the client.
+     *
+     * @return array{0: string, 1: string, 2: int} full nonce, salt, iterations
+     *
+     * @throws SaslException
+     */
+    private function parseServerFirst(
+        Message $serverFirst,
+        string $cnonce
+    ): array {
+        $fullNonce = (string) $serverFirst->get('r');
+        if (strncmp($fullNonce, $cnonce, strlen($cnonce)) !== 0) {
+            throw new SaslException('The server nonce does not begin with the client nonce.');
+        }
+
+        $salt = base64_decode(
+            (string) $serverFirst->get('s'),
+            true
+        );
+        if ($salt === false) {
+            throw new SaslException('The server-provided salt is not valid base64.');
+        }
+
+        $iterations = (int) $serverFirst->get('i');
+        $minIterations = self::MIN_ITERATIONS[$this->hashAlgorithm];
+        if ($iterations < $minIterations) {
+            throw new SaslException(sprintf(
+                'The server iteration count of %d is below the minimum of %d for %s.',
+                $iterations,
+                $minIterations,
+                $this->hashAlgorithm
+            ));
+        }
+        if ($iterations > self::MAX_ITERATIONS) {
+            throw new SaslException(sprintf(
+                'The server iteration count of %d exceeds the maximum allowed of %d.',
+                $iterations,
+                self::MAX_ITERATIONS
+            ));
+        }
+
+        return [
+            $fullNonce,
+            $salt,
+            $iterations
+        ];
+    }
+
+    /**
+     * Applies SASLprep to the password and derives the SCRAM SaltedPassword via PBKDF2.
+     *
+     * @throws SaslException if SASLprep rejects the password.
+     */
+    private function deriveSaltedPassword(
+        string $password,
+        string $salt,
+        int $iterations
+    ): string {
+        return $this->pbkdf2(
+            SaslPrep::prepare($password),
+            $salt,
+            $iterations
+        );
+    }
+
+    /**
+     * Decodes and verifies the client proof from the client-final-message.
+     *
+     * Returns true only when the base64 decoding succeeds and the proof matches.
+     */
+    private function isValidClientProof(
+        Message $clientFinal,
+        string $saltedPassword,
+        string $authMessage
+    ): bool {
+        $expectedProof = $this->makeClientProof(
+            $saltedPassword,
+            $authMessage
+        );
+        $receivedProof = base64_decode(
+            (string) $clientFinal->get('p'),
+            true
+        );
+
+        return $receivedProof !== false
+            && hash_equals($expectedProof, $receivedProof);
+    }
+
+    /**
+     * Computes the SCRAM SaltedPassword using PBKDF2.
+     *
+     *   SaltedPassword := Hi(Normalize(password), salt, i)
+     */
+    private function pbkdf2(
+        string $password,
+        string $salt,
+        int $iterations
+    ): string {
+        return hash_pbkdf2(
+            $this->hashAlgorithm,
+            $password,
+            $salt,
+            $iterations,
+            0,
+            true
+        );
+    }
+
+    /**
+     * Computes an HMAC with the configured hash algorithm, returning raw bytes.
+     */
+    private function hmac(
+        string $key,
+        string $data
+    ): string {
+        return hash_hmac(
+            $this->hashAlgorithm,
+            $data,
+            $key,
+            true
+        );
+    }
+
+    /**
+     * Computes a hash with the configured hash algorithm, returning raw bytes.
+     */
+    private function hash(string $data): string
+    {
+        return hash(
+            $this->hashAlgorithm,
+            $data,
+            true
+        );
+    }
+
+    /**
+     * @param string $saltedPassword
+     * @param string $authMessage
+     * @return string
+     */
+    private function makeClientProof(
+        string $saltedPassword,
+        string $authMessage
+    ): string {
+        $clientKey = $this->hmac(
+            $saltedPassword,
+            self::HMAC_CLIENT_KEY
+        );
+        $storedKey = $this->hash($clientKey);
+        $clientSignature = $this->hmac(
+            $storedKey,
+            $authMessage
+        );
+
+        return $clientKey ^ $clientSignature;
+    }
+
+    /**
+     * RFC 5801 §4: cb-type = 1*(ALPHA / DIGIT / "." / "-"). Reject anything else to prevent
+     * GS2 header injection (e.g. a type containing ',,' would corrupt the auth-message).
+     *
+     * @throws SaslException
+     */
+    private function validateCbindType(string $cbindType): void
+    {
+        if (!preg_match('/^[A-Za-z0-9.\-]+$/', $cbindType)) {
+            throw new SaslException(
+                'The channel binding type contains invalid characters. ' .
+                'Only alphanumeric characters, hyphens, and dots are permitted.'
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Sasl/Encoder/ScramEncoder.php
+++ b/src/FreeDSx/Sasl/Encoder/ScramEncoder.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Sasl\Encoder;
+
+use FreeDSx\Sasl\Exception\SaslEncodingException;
+use FreeDSx\Sasl\Message;
+use FreeDSx\Sasl\SaslContext;
+
+/**
+ * Responsible for encoding / decoding SCRAM messages.
+ *
+ * SCRAM wire format is comma-separated attr=value pairs (RFC 5802). The client-first-message
+ * is prefixed by a GS2 header ('n,,', 'y,,', or 'p=type,,') before the client-first-message-bare.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class ScramEncoder implements EncoderInterface
+{
+    /**
+     * Matches the GS2 header at the start of a client-first-message.
+     *
+     * Formats: 'n,,', 'y,,', 'p=<cbtype>,,'
+     */
+    private const MATCH_GS2_HEADER = '/^(n|y|p=[^,]*),,(.*)$/';
+
+    /**
+     * {@inheritDoc}
+     *
+     * Encodes a Message into a SCRAM comma-separated attr=value string.
+     */
+    public function encode(Message $message, SaslContext $context): string
+    {
+        $parts = [];
+
+        foreach ($message->toArray() as $attr => $value) {
+            $parts[] = $attr . '=' . $value;
+        }
+
+        return implode(',', $parts);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Decodes a SCRAM message string into a Message object.
+     *
+     * For client-first-messages the GS2 header is extracted and stored under the
+     * 'gs2-header' key, and the remainder is parsed as attr=value pairs.
+     *
+     * @throws SaslEncodingException
+     */
+    public function decode(string $data, SaslContext $context): Message
+    {
+        $message = new Message();
+
+        # Detect and strip the GS2 header present in client-first-messages.
+        if (preg_match(self::MATCH_GS2_HEADER, $data, $matches)) {
+            $message->set('gs2-header', $matches[1] . ',,');
+            $data = $matches[2];
+        }
+
+        # SCRAM attr values are printable ASCII excluding comma, so splitting on comma is safe.
+        $parts = explode(',', $data);
+        foreach ($parts as $part) {
+            $eqPos = strpos($part, '=');
+            if ($eqPos === false) {
+                throw new SaslEncodingException(sprintf(
+                    'Malformed SCRAM message attribute (no "=" separator found): "%s".',
+                    $part
+                ));
+            }
+
+            $attr = substr($part, 0, $eqPos);
+            # The value may itself contain '=' (e.g. base64 padding), so we only split on the first '='.
+            $value = substr($part, $eqPos + 1);
+
+            # RFC 5802 section 5: an unknown mandatory extension (m=) must cause authentication to fail.
+            if ($attr === 'm') {
+                throw new SaslEncodingException('Received an unsupported mandatory SCRAM extension (m=).');
+            }
+
+            $message->set($attr, $value);
+        }
+
+        return $message;
+    }
+}

--- a/src/FreeDSx/Sasl/Mechanism/ScramMechanism.php
+++ b/src/FreeDSx/Sasl/Mechanism/ScramMechanism.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Sasl\Mechanism;
+
+use FreeDSx\Sasl\Challenge\ChallengeInterface;
+use FreeDSx\Sasl\Challenge\ScramChallenge;
+use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\Security\SecurityLayerInterface;
+use FreeDSx\Sasl\SecurityStrength;
+
+/**
+ * A single class covering all SCRAM mechanism variants (RFC 5802 / RFC 7677).
+ *
+ * Instantiate with one of the NAME_* constants to select the variant:
+ *
+ *   new ScramMechanism(ScramMechanism::SHA256)
+ *   new ScramMechanism(ScramMechanism::SHA256_PLUS)
+ *
+ * SCRAM does not define a post-authentication security layer; TLS is expected to
+ * provide confidentiality and integrity instead.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class ScramMechanism implements MechanismInterface
+{
+    public const SHA1 = 'SCRAM-SHA-1';
+    public const SHA1_PLUS = 'SCRAM-SHA-1-PLUS';
+    public const SHA224 = 'SCRAM-SHA-224';
+    public const SHA224_PLUS = 'SCRAM-SHA-224-PLUS';
+    public const SHA256 = 'SCRAM-SHA-256';
+    public const SHA256_PLUS = 'SCRAM-SHA-256-PLUS';
+    public const SHA384 = 'SCRAM-SHA-384';
+    public const SHA384_PLUS = 'SCRAM-SHA-384-PLUS';
+    public const SHA512 = 'SCRAM-SHA-512';
+    public const SHA512_PLUS = 'SCRAM-SHA-512-PLUS';
+    public const SHA3_512 = 'SCRAM-SHA3-512';
+    public const SHA3_512_PLUS = 'SCRAM-SHA3-512-PLUS';
+
+    public const VARIANTS = [
+        self::SHA1,
+        self::SHA1_PLUS,
+        self::SHA224,
+        self::SHA224_PLUS,
+        self::SHA256,
+        self::SHA256_PLUS,
+        self::SHA384,
+        self::SHA384_PLUS,
+        self::SHA512,
+        self::SHA512_PLUS,
+        self::SHA3_512,
+        self::SHA3_512_PLUS,
+    ];
+
+    /**
+     * Maps SASL mechanism name to [php_hash_algorithm, channel_binding].
+     *
+     * The PHP algorithm names are used directly with hash(), hash_hmac(), and hash_pbkdf2().
+     */
+    private const MECHANISMS = [
+        self::SHA1          => ['sha1', false],
+        self::SHA1_PLUS     => ['sha1', true],
+        self::SHA224        => ['sha224', false],
+        self::SHA224_PLUS   => ['sha224', true],
+        self::SHA256        => ['sha256', false],
+        self::SHA256_PLUS   => ['sha256', true],
+        self::SHA384        => ['sha384', false],
+        self::SHA384_PLUS   => ['sha384', true],
+        self::SHA512        => ['sha512', false],
+        self::SHA512_PLUS   => ['sha512', true],
+        self::SHA3_512      => ['sha3-512', false],
+        self::SHA3_512_PLUS => ['sha3-512', true],
+    ];
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $hashAlgorithm;
+
+    /**
+     * @var bool
+     */
+    private $channelBinding;
+
+    /**
+     * @throws SaslException
+     */
+    public function __construct(string $name)
+    {
+        if (!isset(self::MECHANISMS[$name])) {
+            throw new SaslException(sprintf(
+                'The SCRAM variant "%s" is not supported. Supported variants: %s.',
+                $name,
+                implode(', ', array_keys(self::MECHANISMS))
+            ));
+        }
+
+        $this->name = $name;
+        [
+            $this->hashAlgorithm,
+            $this->channelBinding,
+        ] = self::MECHANISMS[$name];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function challenge(): ChallengeInterface
+    {
+        return new ScramChallenge(false, $this->hashAlgorithm, $this->channelBinding);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function securityStrength(): SecurityStrength
+    {
+        return new SecurityStrength(
+            false,
+            false,
+            true,
+            false,
+            0
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SCRAM does not provide a post-authentication security layer.
+     *
+     * @throws SaslException
+     */
+    public function securityLayer(): SecurityLayerInterface
+    {
+        throw new SaslException(sprintf(
+            'The %s mechanism does not provide a security layer.',
+            $this->name
+        ));
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/FreeDSx/Sasl/Sasl.php
+++ b/src/FreeDSx/Sasl/Sasl.php
@@ -17,6 +17,7 @@ use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
 use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
 use FreeDSx\Sasl\Mechanism\MechanismInterface;
 use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
 
 /**
  * The main SASL class.
@@ -122,6 +123,10 @@ class Sasl
             PlainMechanism::NAME => new PlainMechanism(),
             AnonymousMechanism::NAME => new AnonymousMechanism(),
         ];
+
+        foreach (ScramMechanism::VARIANTS as $variant) {
+            $this->mechanisms[$variant] = new ScramMechanism($variant);
+        }
 
         if (is_array($this->options['supported']) && !empty($this->options['supported'])) {
             foreach (array_keys($this->mechanisms) as $mechName) {

--- a/src/FreeDSx/Sasl/SaslPrep.php
+++ b/src/FreeDSx/Sasl/SaslPrep.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Sasl;
+
+use FreeDSx\Sasl\Exception\SaslException;
+
+/**
+ * Implements the SASLprep string preparation profile (RFC 4013) over the stringprep framework (RFC 3454).
+ *
+ * Implements: B.1 map-to-nothing, C.1.2 space mapping, and prohibition checks C.2.1–C.2.2 (partial),
+ * C.3–C.4 (BMP only), C.5 (via UTF-8 validity), C.6–C.9.
+ *
+ * Known gaps: NFKC normalization (requires ext-intl; affects non-ASCII inputs with multiple Unicode
+ * representations), bidi check (RFC 3454 §6), supplementary-plane private use / non-character code
+ * points (C.3/C.4), and non-C1 scattered control points (C.2.2). ASCII-only inputs are fully compliant.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class SaslPrep
+{
+    /**
+     * Maps named capture group names (from PROHIBITED_PATTERN) to their exception messages.
+     * C.2.1 and C.2.2 share the 'control' group since they produce the same error.
+     */
+    private const PROHIBITED_ERRORS = [
+        'control'   => self::ERR_CONTROL_CHAR,
+        'private'   => self::ERR_PRIVATE_USE,
+        'nonchar'   => self::ERR_NON_CHARACTER,
+        'plaintext' => self::ERR_PLAIN_TEXT,
+        'canonical' => self::ERR_CANONICAL,
+        'display'   => self::ERR_DISPLAY_PROP,
+        'tagging'   => self::ERR_TAGGING,
+    ];
+
+    /**
+     * Single-pass pattern covering all RFC 4013 §2.3 prohibited ranges via named groups.
+     * C.2.1 (ASCII control) and C.2.2 (C1 control) share the 'control' group.
+     * C.5 (surrogates) is handled by mb_check_encoding rather than regex (PCRE2 disallows
+     * surrogate ranges in Unicode character classes, and valid UTF-8 cannot encode them anyway).
+     * See class docblock for remaining known gaps.
+     */
+    private const PROHIBITED_PATTERN =
+        '/(?P<control>[\x00-\x1F\x7F\x{0080}-\x{009F}])'      // C.2.1 + C.2.2
+        . '|(?P<private>[\x{E000}-\x{F8FF}])'                 // C.3
+        . '|(?P<nonchar>[\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}])' // C.4
+        . '|(?P<plaintext>[\x{FFF9}-\x{FFFD}])'               // C.6
+        . '|(?P<canonical>[\x{2FF0}-\x{2FFB}])'               // C.7
+        . '|(?P<display>[\x{0340}\x{0341}\x{200E}\x{200F}\x{202A}-\x{202E}\x{206A}-\x{206F}])' // C.8
+        . '|(?P<tagging>[\x{E0001}\x{E0020}-\x{E007F}])/u';   // C.9
+
+    /**
+     * Characters from RFC 3454 Table B.1 that are commonly mapped to nothing.
+     * Applied as the first step, before space mapping and normalization.
+     */
+    private const MAP_TO_NOTHING = [
+        "\u{00AD}", // SOFT HYPHEN
+        "\u{034F}", // COMBINING GRAPHEME JOINER
+        "\u{1806}", // MONGOLIAN TODO SOFT HYPHEN
+        "\u{180B}", // MONGOLIAN FREE VARIATION SELECTOR ONE
+        "\u{180C}", // MONGOLIAN FREE VARIATION SELECTOR TWO
+        "\u{180D}", // MONGOLIAN FREE VARIATION SELECTOR THREE
+        "\u{200B}", // ZERO WIDTH SPACE
+        "\u{200C}", // ZERO WIDTH NON-JOINER
+        "\u{200D}", // ZERO WIDTH JOINER
+        "\u{2060}", // WORD JOINER
+        "\u{FE00}", // VARIATION SELECTOR-1
+        "\u{FE01}", // VARIATION SELECTOR-2
+        "\u{FE02}", // VARIATION SELECTOR-3
+        "\u{FE03}", // VARIATION SELECTOR-4
+        "\u{FE04}", // VARIATION SELECTOR-5
+        "\u{FE05}", // VARIATION SELECTOR-6
+        "\u{FE06}", // VARIATION SELECTOR-7
+        "\u{FE07}", // VARIATION SELECTOR-8
+        "\u{FE08}", // VARIATION SELECTOR-9
+        "\u{FE09}", // VARIATION SELECTOR-10
+        "\u{FE0A}", // VARIATION SELECTOR-11
+        "\u{FE0B}", // VARIATION SELECTOR-12
+        "\u{FE0C}", // VARIATION SELECTOR-13
+        "\u{FE0D}", // VARIATION SELECTOR-14
+        "\u{FE0E}", // VARIATION SELECTOR-15
+        "\u{FE0F}", // VARIATION SELECTOR-16
+        "\u{FEFF}", // ZERO WIDTH NO-BREAK SPACE (BOM)
+    ];
+
+    /**
+     * Non-ASCII space characters from RFC 3454 Table C.1.2.
+     * Each is mapped to a single ASCII space (U+0020).
+     * Note: U+200B is intentionally absent — it is already deleted by MAP_TO_NOTHING (Table B.1).
+     */
+    private const MAP_TO_SPACE = [
+        "\u{00A0}", // NO-BREAK SPACE
+        "\u{1680}", // OGHAM SPACE MARK
+        "\u{2000}", // EN QUAD
+        "\u{2001}", // EM QUAD
+        "\u{2002}", // EN SPACE
+        "\u{2003}", // EM SPACE
+        "\u{2004}", // THREE-PER-EM SPACE
+        "\u{2005}", // FOUR-PER-EM SPACE
+        "\u{2006}", // SIX-PER-EM SPACE
+        "\u{2007}", // FIGURE SPACE
+        "\u{2008}", // PUNCTUATION SPACE
+        "\u{2009}", // THIN SPACE
+        "\u{200A}", // HAIR SPACE
+        "\u{2028}", // LINE SEPARATOR
+        "\u{2029}", // PARAGRAPH SEPARATOR
+        "\u{202F}", // NARROW NO-BREAK SPACE
+        "\u{205F}", // MEDIUM MATHEMATICAL SPACE
+        "\u{3000}", // IDEOGRAPHIC SPACE
+    ];
+
+    private const ERR_CONTROL_CHAR   = 'String contains a prohibited control character.';
+
+    private const ERR_PRIVATE_USE    = 'String contains a prohibited private use character.';
+
+    private const ERR_NON_CHARACTER  = 'String contains a prohibited non-character code point.';
+
+    private const ERR_PLAIN_TEXT     = 'String contains a character inappropriate for plain text.';
+
+    private const ERR_CANONICAL      = 'String contains a character inappropriate for canonical representation.';
+
+    private const ERR_DISPLAY_PROP   = 'String contains a deprecated or display-property-altering character.';
+
+    private const ERR_TAGGING        = 'String contains a prohibited tagging character.';
+
+    /**
+     * Prepares a string according to the SASLprep profile (RFC 4013).
+     *
+     * @throws SaslException if the string is not valid UTF-8 or contains a prohibited character.
+     */
+    public static function prepare(string $input): string
+    {
+        // Step 1: Map characters commonly mapped to nothing (RFC 3454 Table B.1).
+        $input = str_replace(
+            self::MAP_TO_NOTHING,
+            '',
+            $input
+        );
+
+        // Step 2: Map non-ASCII space characters to ASCII space (RFC 3454 Table C.1.2).
+        $input = str_replace(
+            self::MAP_TO_SPACE,
+            ' ',
+            $input
+        );
+
+        // @TODO Step 3: Unicode NFKC normalization (RFC 3454 §7).
+
+        // Step 4: Check for prohibited output characters (RFC 4013 §2.3).
+        self::checkProhibited($input);
+
+        // @TODO Step 5: Bidirectional check (RFC 3454 §6).
+
+        return $input;
+    }
+
+    /**
+     * Checks the string for prohibited output characters per RFC 4013 §2.3.
+     *
+     * @throws SaslException
+     */
+    private static function checkProhibited(string $input): void
+    {
+        if (!mb_check_encoding($input, 'UTF-8')) {
+            throw new SaslException('The string is not valid UTF-8.');
+        }
+
+        if (preg_match(self::PROHIBITED_PATTERN, $input, $matches) !== 1) {
+            return;
+        }
+
+        foreach (self::PROHIBITED_ERRORS as $group => $message) {
+            if (isset($matches[$group]) && $matches[$group] !== '') {
+                throw new SaslException($message);
+            }
+        }
+    }
+}

--- a/tests/unit/FreeDSx/Sasl/Challenge/ScramChallengeTest.php
+++ b/tests/unit/FreeDSx/Sasl/Challenge/ScramChallengeTest.php
@@ -1,0 +1,481 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace unit\FreeDSx\Sasl\Challenge;
+
+use FreeDSx\Sasl\Challenge\ScramChallenge;
+use FreeDSx\Sasl\Exception\SaslException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test vectors from RFC 5802 Appendix B (SCRAM-SHA-1):
+ *
+ *   username:  user
+ *   password:  pencil
+ *   cnonce:    fyko+d2lbbFgONRv9qkxdawL
+ *   snonce:    3rfcNHYJY1ZVvWVs7j
+ *   salt:      QSXCR+Q6sek8bf92  (base64)
+ *   iterations: 4096
+ *
+ *   C: n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL
+ *   S: r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096
+ *   C: c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=
+ *   S: v=rmF9pqV8S7suAoZWja4dJRkFsKQ=
+ */
+class ScramChallengeTest extends TestCase
+{
+    private const USERNAME   = 'user';
+    private const PASSWORD   = 'pencil';
+    private const CNONCE     = 'fyko+d2lbbFgONRv9qkxdawL';
+    private const SNONCE     = '3rfcNHYJY1ZVvWVs7j';
+    private const SALT_B64   = 'QSXCR+Q6sek8bf92';
+    private const ITERATIONS = 4096;
+
+    private const CLIENT_FIRST = 'n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL';
+    private const SERVER_FIRST = 'r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096';
+    private const CLIENT_FINAL = 'c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=';
+    private const SERVER_FINAL = 'v=rmF9pqV8S7suAoZWja4dJRkFsKQ=';
+
+    /**
+     * @var ScramChallenge
+     */
+    private $challenge;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->challenge = new ScramChallenge(false, 'sha1');
+    }
+
+    public function testClientFirstMessageMatchesRfcVector(): void
+    {
+        $context = $this->challenge->challenge(null, [
+            'username' => self::USERNAME,
+            'cnonce'   => self::CNONCE,
+        ]);
+
+        $this->assertSame(
+            self::CLIENT_FIRST,
+            $context->getResponse()
+        );
+        $this->assertFalse($context->isComplete());
+    }
+
+    public function testClientFinalMessageMatchesRfcVector(): void
+    {
+        $this->challenge->challenge(null, [
+            'username' => self::USERNAME,
+            'cnonce'   => self::CNONCE,
+        ]);
+
+        $context = $this->challenge->challenge(self::SERVER_FIRST, [
+            'password' => self::PASSWORD,
+        ]);
+
+        $this->assertSame(
+            self::CLIENT_FINAL,
+            $context->getResponse()
+        );
+        $this->assertFalse($context->isComplete());
+    }
+
+    public function testClientCompletesAndAuthenticatesOnValidServerFinal(): void
+    {
+        $this->challenge->challenge(
+            null,
+            [
+                'username' => self::USERNAME,
+                'cnonce' => self::CNONCE
+            ]
+        );
+        $this->challenge->challenge(
+            self::SERVER_FIRST,
+            ['password' => self::PASSWORD]
+        );
+        $context = $this->challenge->challenge(self::SERVER_FINAL);
+
+        $this->assertNull($context->getResponse());
+        $this->assertTrue($context->isComplete());
+        $this->assertTrue($context->isAuthenticated());
+    }
+
+    public function testClientThrowsExceptionOnServerFinalWithError(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            [
+                'username' => self::USERNAME,
+                'cnonce' => self::CNONCE
+            ]
+        );
+        $this->challenge->challenge(
+            self::SERVER_FIRST,
+            ['password' => self::PASSWORD]
+        );
+        $this->challenge->challenge('e=unknown-user');
+    }
+
+    public function testClientThrowsExceptionOnInvalidServerSignature(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            ['username' => self::USERNAME, 'cnonce' => self::CNONCE]
+        );
+        $this->challenge->challenge(
+            self::SERVER_FIRST,
+            ['password' => self::PASSWORD]
+        );
+        $this->challenge->challenge('v=aW52YWxpZHNpZ25hdHVyZQ==');
+    }
+
+    public function testClientThrowsExceptionWhenNonceDoesNotBeginWithClientNonce(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            [
+                'username' => self::USERNAME,
+                'cnonce' => self::CNONCE
+            ]
+        );
+        // Server-first with a nonce that doesn't start with the client nonce
+        $this->challenge->challenge(
+            'r=wrongnonce,s=' . self::SALT_B64 . ',i=' . self::ITERATIONS,
+            ['password' => self::PASSWORD]
+        );
+    }
+
+    public function testClientThrowsExceptionWhenUsernameIsMissing(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge();
+    }
+
+    public function testClientThrowsExceptionWhenPasswordIsMissing(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            [
+                'username' => self::USERNAME,
+                'cnonce' => self::CNONCE
+            ]
+        );
+        $this->challenge->challenge(self::SERVER_FIRST);
+    }
+
+    public function testClientEncodesSpecialCharactersInUsername(): void
+    {
+        $context = $this->challenge->challenge(null, [
+            'username' => 'user=name,test',
+            'cnonce'   => self::CNONCE,
+        ]);
+
+        $this->assertStringContainsString(
+            'n=user=3Dname=2Ctest',
+            (string) $context->getResponse()
+        );
+    }
+
+    public function testChannelBindingClientFirstUsesCorrectGs2Header(): void
+    {
+        $plusChallenge = new ScramChallenge(false, 'sha256', true);
+        $context = $plusChallenge->challenge(null, [
+            'username'   => self::USERNAME,
+            'cnonce'     => self::CNONCE,
+            'cbind_type' => 'tls-unique',
+        ]);
+
+        $this->assertStringStartsWith(
+            'p=tls-unique,,',
+            (string) $context->getResponse()
+        );
+    }
+
+    public function testServerReturnsNullResponseForInitialCall(): void
+    {
+        $server = new ScramChallenge(
+            true,
+            'sha1',
+            false
+        );
+        $context = $server->challenge();
+
+        $this->assertNull($context->getResponse());
+        $this->assertFalse($context->isComplete());
+    }
+
+    public function testServerFirstMessageContainsClientNoncePrefix(): void
+    {
+        $server = new ScramChallenge(
+            true,
+            'sha1',
+            false
+        );
+        $context = $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => self::ITERATIONS,
+        ]);
+
+        $this->assertSame(
+            self::SERVER_FIRST,
+            $context->getResponse()
+        );
+        $this->assertFalse($context->isComplete());
+    }
+
+    public function testServerFinalMessageOnValidProof(): void
+    {
+        $server = new ScramChallenge(
+            true,
+            'sha1',
+            false
+        );
+        $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => self::ITERATIONS,
+        ]);
+        $context = $server->challenge(
+            self::CLIENT_FINAL,
+            ['password' => self::PASSWORD]
+        );
+
+        $this->assertSame(
+            self::SERVER_FINAL,
+            $context->getResponse()
+        );
+        $this->assertTrue($context->isComplete());
+        $this->assertTrue($context->isAuthenticated());
+    }
+
+    public function testServerFinalMessageOnInvalidProof(): void
+    {
+        $server = new ScramChallenge(true, 'sha1', false);
+        $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => self::ITERATIONS,
+        ]);
+        // Send a valid-looking client-final but with the wrong password on the server
+        $context = $server->challenge(self::CLIENT_FINAL, ['password' => 'wrongpassword']);
+
+        $this->assertStringStartsWith(
+            'e=',
+            (string) $context->getResponse()
+        );
+        $this->assertTrue($context->isComplete());
+        $this->assertFalse($context->isAuthenticated());
+    }
+
+    public function testServerFinalMessageWhenPasswordIsMissing(): void
+    {
+        $server = new ScramChallenge(
+            true,
+            'sha1',
+            false
+        );
+        $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => self::ITERATIONS,
+        ]);
+        $context = $server->challenge(self::CLIENT_FINAL, []);
+
+        $this->assertSame(
+            'e=invalid-proof',
+            $context->getResponse()
+        );
+        $this->assertTrue($context->isComplete());
+        $this->assertFalse($context->isAuthenticated());
+    }
+
+    public function testClientThrowsExceptionWhenServerIterationCountIsBelowMinimum(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            ['username' => self::USERNAME, 'cnonce' => self::CNONCE]
+        );
+        // i=1 is below the SHA-1 minimum of 4096
+        $this->challenge->challenge(
+            'r=' . self::CNONCE . self::SNONCE . ',s=' . self::SALT_B64 . ',i=1',
+            ['password' => self::PASSWORD]
+        );
+    }
+
+    public function testServerThrowsExceptionWhenSuppliedIterationCountIsZero(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $server = new ScramChallenge(true, 'sha1', false);
+        $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => 0,
+        ]);
+    }
+
+    public function testClientThrowsExceptionOnInvalidBase64Salt(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            ['username' => self::USERNAME, 'cnonce' => self::CNONCE]
+        );
+        // s= value is not valid base64
+        $this->challenge->challenge(
+            'r=' . self::CNONCE . self::SNONCE . ',s=not!!valid!!base64,i=' . self::ITERATIONS,
+            ['password' => self::PASSWORD]
+        );
+    }
+
+    public function testServerReturnsInvalidProofOnMalformedBase64Proof(): void
+    {
+        $server = new ScramChallenge(true, 'sha1', false);
+        $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => self::ITERATIONS,
+        ]);
+        // Replace the valid proof with invalid base64
+        $tampered = preg_replace('/,p=[^,]+$/', ',p=not!!valid', self::CLIENT_FINAL);
+        $context = $server->challenge($tampered, ['password' => self::PASSWORD]);
+
+        $this->assertSame('e=invalid-proof', $context->getResponse());
+        $this->assertFalse($context->isAuthenticated());
+    }
+
+    public function testClientThrowsExceptionWhenClientFinalCalledWithoutClientFirst(): void
+    {
+        $this->expectException(SaslException::class);
+
+        // Skip client-first and call directly with a server-first message
+        $this->challenge->challenge(
+            self::SERVER_FIRST,
+            ['password' => self::PASSWORD]
+        );
+    }
+
+    public function testClientThrowsExceptionOnInvalidChannelBindingType(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $plusChallenge = new ScramChallenge(false, 'sha256', true);
+        $plusChallenge->challenge(null, [
+            'username'   => self::USERNAME,
+            'cnonce'     => self::CNONCE,
+            'cbind_type' => 'invalid,,type',
+        ]);
+    }
+
+    public function testThrowsExceptionOnUnsupportedHashAlgorithm(): void
+    {
+        $this->expectException(SaslException::class);
+
+        new ScramChallenge(false, 'md5');
+    }
+
+    public function testClientThrowsExceptionWhenServerIterationCountExceedsMaximum(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(
+            null,
+            ['username' => self::USERNAME, 'cnonce' => self::CNONCE]
+        );
+        $this->challenge->challenge(
+            'r=' . self::CNONCE . self::SNONCE . ',s=' . self::SALT_B64 . ',i=1000001',
+            ['password' => self::PASSWORD]
+        );
+    }
+
+    public function testServerThrowsExceptionWhenSuppliedIterationCountExceedsMaximum(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $server = new ScramChallenge(true, 'sha1', false);
+        $server->challenge(self::CLIENT_FIRST, [
+            'nonce'      => self::SNONCE,
+            'salt'       => base64_decode(self::SALT_B64),
+            'iterations' => 1000001,
+        ]);
+    }
+
+    public function testClientThrowsExceptionOnEmptyCnonce(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->challenge->challenge(null, [
+            'username' => self::USERNAME,
+            'cnonce'   => '',
+        ]);
+    }
+
+    public function testFullClientServerRoundTrip(): void
+    {
+        $client = new ScramChallenge(
+            false,
+            'sha256'
+        );
+        $server = new ScramChallenge(
+            true,
+            'sha256',
+            false
+        );
+
+        // Round 1: client-first -> server
+        $clientFirst = $client->challenge(
+            null,
+            ['username' => self::USERNAME]
+        )->getResponse();
+        $this->assertNotNull($clientFirst);
+
+        // Round 2: server processes client-first, sends server-first
+        $serverFirst = $server->challenge($clientFirst)->getResponse();
+        $this->assertNotNull($serverFirst);
+
+        // Round 3: client processes server-first, sends client-final
+        $clientFinal = $client->challenge(
+            $serverFirst,
+            ['password' => self::PASSWORD]
+        )->getResponse();
+        $this->assertNotNull($clientFinal);
+
+        // Round 4: server processes client-final, sends server-final
+        $serverContext = $server->challenge(
+            $clientFinal,
+            ['password' => self::PASSWORD]
+        );
+        $serverFinal = $serverContext->getResponse();
+        $this->assertStringStartsWith(
+            'v=',
+            (string) $serverFinal
+        );
+        $this->assertTrue($serverContext->isAuthenticated());
+
+        // Round 5: client verifies server-final
+        $clientContext = $client->challenge($serverFinal);
+        $this->assertTrue($clientContext->isComplete());
+        $this->assertTrue($clientContext->isAuthenticated());
+    }
+}

--- a/tests/unit/FreeDSx/Sasl/Encoder/ScramEncoderTest.php
+++ b/tests/unit/FreeDSx/Sasl/Encoder/ScramEncoderTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace unit\FreeDSx\Sasl\Encoder;
+
+use FreeDSx\Sasl\Encoder\ScramEncoder;
+use FreeDSx\Sasl\Exception\SaslEncodingException;
+use FreeDSx\Sasl\Message;
+use FreeDSx\Sasl\SaslContext;
+use PHPUnit\Framework\TestCase;
+
+class ScramEncoderTest extends TestCase
+{
+    /**
+     * @var ScramEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var SaslContext
+     */
+    private $context;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->encoder = new ScramEncoder();
+        $this->context = new SaslContext();
+    }
+
+    public function testEncodeProducesCommaSeparatedAttrValuePairs(): void
+    {
+        $message = new Message([
+            'n' => 'user',
+            'r' => 'fyko+d2lbbFgONRv9qkxdawL',
+        ]);
+
+        $encoded = $this->encoder->encode($message, $this->context);
+
+        $this->assertSame(
+            'n=user,r=fyko+d2lbbFgONRv9qkxdawL',
+            $encoded
+        );
+    }
+
+    public function testEncodePreservesBase64ValuesWithEqualSigns(): void
+    {
+        $message = new Message([
+            'v' => 'rmF9pqV8S7suAoZWja4dJRkFsKQ=',
+        ]);
+
+        $this->assertSame(
+            'v=rmF9pqV8S7suAoZWja4dJRkFsKQ=',
+            $this->encoder->encode($message, $this->context)
+        );
+    }
+
+    public function testDecodeClientFirstMessageStripsGs2Header(): void
+    {
+        // n,, is the GS2 header for a standard (non-channel-binding) client-first-message
+        $decoded = $this->encoder->decode('n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL', $this->context);
+
+        $this->assertSame(
+            'n,,',
+            $decoded->get('gs2-header')
+        );
+        $this->assertSame(
+            'user',
+            $decoded->get('n')
+        );
+        $this->assertSame(
+            'fyko+d2lbbFgONRv9qkxdawL',
+            $decoded->get('r')
+        );
+    }
+
+    public function testDecodeClientFirstMessageWithChannelBindingGs2Header(): void
+    {
+        $decoded = $this->encoder->decode('p=tls-unique,,n=user,r=clientnonce', $this->context);
+
+        $this->assertSame(
+            'p=tls-unique,,',
+            $decoded->get('gs2-header')
+        );
+        $this->assertSame(
+            'user',
+            $decoded->get('n')
+        );
+        $this->assertSame(
+            'clientnonce',
+            $decoded->get('r')
+        );
+    }
+
+    public function testDecodeClientFirstMessageWithYGs2Header(): void
+    {
+        $decoded = $this->encoder->decode('y,,n=user,r=clientnonce', $this->context);
+
+        $this->assertSame(
+            'y,,',
+            $decoded->get('gs2-header')
+        );
+        $this->assertSame(
+            'user',
+            $decoded->get('n')
+        );
+    }
+
+    public function testDecodeServerFirstMessage(): void
+    {
+        $decoded = $this->encoder->decode(
+            'r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096',
+            $this->context
+        );
+
+        $this->assertSame(
+            'fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j',
+            $decoded->get('r')
+        );
+        $this->assertSame(
+            'QSXCR+Q6sek8bf92',
+            $decoded->get('s')
+        );
+        $this->assertSame(
+            '4096',
+            $decoded->get('i')
+        );
+        $this->assertNull($decoded->get('gs2-header'));
+    }
+
+    public function testDecodeClientFinalMessage(): void
+    {
+        $decoded = $this->encoder->decode(
+            'c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=',
+            $this->context
+        );
+
+        $this->assertSame(
+            'biws',
+            $decoded->get('c')
+        );
+        $this->assertSame(
+            'fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j',
+            $decoded->get('r')
+        );
+        $this->assertSame(
+            'v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=',
+            $decoded->get('p')
+        );
+    }
+
+    public function testDecodeServerFinalMessage(): void
+    {
+        $decoded = $this->encoder->decode(
+            'v=rmF9pqV8S7suAoZWja4dJRkFsKQ=',
+            $this->context
+        );
+
+        $this->assertSame(
+            'rmF9pqV8S7suAoZWja4dJRkFsKQ=',
+            $decoded->get('v')
+        );
+    }
+
+    public function testDecodeThrowsOnMalformedAttributeWithNoEquals(): void
+    {
+        $this->expectException(SaslEncodingException::class);
+
+        $this->encoder->decode(
+            'r=validnonce,malformed',
+            $this->context
+        );
+    }
+
+    public function testDecodeThrowsOnMandatoryExtension(): void
+    {
+        $this->expectException(SaslEncodingException::class);
+
+        $this->encoder->decode(
+            'm=unsupported,r=nonce',
+            $this->context
+        );
+    }
+}

--- a/tests/unit/FreeDSx/Sasl/Mechanism/ScramMechanismTest.php
+++ b/tests/unit/FreeDSx/Sasl/Mechanism/ScramMechanismTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace unit\FreeDSx\Sasl\Mechanism;
+
+use FreeDSx\Sasl\Challenge\ScramChallenge;
+use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use PHPUnit\Framework\TestCase;
+
+class ScramMechanismTest extends TestCase
+{
+    /**
+     * @var ScramMechanism
+     */
+    private $mechanism;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mechanism = new ScramMechanism(ScramMechanism::SHA256);
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertSame(
+            'SCRAM-SHA-256',
+            $this->mechanism->getName()
+        );
+    }
+
+    /**
+     * @dataProvider variantNameProvider
+     */
+    public function testGetNameForAllVariants(string $name): void
+    {
+        $mechanism = new ScramMechanism($name);
+
+        $this->assertSame(
+            $name,
+            $mechanism->getName()
+        );
+    }
+
+    public function variantNameProvider(): array
+    {
+        return [
+            [ScramMechanism::SHA1],
+            [ScramMechanism::SHA1_PLUS],
+            [ScramMechanism::SHA224],
+            [ScramMechanism::SHA224_PLUS],
+            [ScramMechanism::SHA256],
+            [ScramMechanism::SHA256_PLUS],
+            [ScramMechanism::SHA384],
+            [ScramMechanism::SHA384_PLUS],
+            [ScramMechanism::SHA512],
+            [ScramMechanism::SHA512_PLUS],
+            [ScramMechanism::SHA3_512],
+            [ScramMechanism::SHA3_512_PLUS],
+        ];
+    }
+
+    public function testSecurityStrength(): void
+    {
+        $strength = $this->mechanism->securityStrength();
+
+        $this->assertFalse($strength->supportsPrivacy());
+        $this->assertFalse($strength->supportsIntegrity());
+        $this->assertTrue($strength->supportsAuth());
+        $this->assertFalse($strength->isPlainTextAuth());
+        $this->assertSame(0, $strength->maxKeySize());
+    }
+
+    public function testSecurityLayerThrowsAnException(): void
+    {
+        $this->expectException(SaslException::class);
+
+        $this->mechanism->securityLayer();
+    }
+
+    public function testChallengeReturnsScramChallenge(): void
+    {
+        $this->assertInstanceOf(ScramChallenge::class, $this->mechanism->challenge());
+    }
+
+    public function testInvalidVariantThrowsAnException(): void
+    {
+        $this->expectException(SaslException::class);
+
+        new ScramMechanism('SCRAM-MD5');
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame(
+            'SCRAM-SHA-256',
+            (string) $this->mechanism
+        );
+    }
+}

--- a/tests/unit/FreeDSx/Sasl/SaslPrepTest.php
+++ b/tests/unit/FreeDSx/Sasl/SaslPrepTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx SASL package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace unit\FreeDSx\Sasl;
+
+use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\SaslPrep;
+use PHPUnit\Framework\TestCase;
+
+class SaslPrepTest extends TestCase
+{
+    /**
+     * @dataProvider mappingCases
+     */
+    public function testPrepare(string $input, string $expected, string $message): void
+    {
+        $this->assertSame(
+            $expected,
+            SaslPrep::prepare($input),
+            $message
+        );
+    }
+
+    /**
+     * @dataProvider prohibitedCases
+     */
+    public function testPrepareThrowsOnProhibitedCharacter(string $input): void
+    {
+        $this->expectException(SaslException::class);
+
+        SaslPrep::prepare($input);
+    }
+
+    public function mappingCases(): array
+    {
+        return [
+            ['user', 'user', 'ASCII string is returned unchanged'],
+            ['hello world', 'hello world', 'ASCII string with space is returned unchanged'],
+
+            // RFC 3454 Table B.1 — map to nothing
+            ["pass\u{00AD}word", 'password', 'soft hyphen (U+00AD) is removed'],
+            ["pass\u{200B}word", 'password', 'zero width space (U+200B) is removed'],
+            ["pass\u{FE0F}word", 'password', 'variation selector-16 (U+FE0F) is removed'],
+            ["\u{FEFF}password", 'password', 'byte order mark (U+FEFF) is removed'],
+            ["p\u{00AD}a\u{034F}s\u{2060}s", 'pass', 'multiple map-to-nothing characters are all removed'],
+
+            // RFC 3454 Table C.1.2 — map to ASCII space
+            ["hello\u{00A0}world", 'hello world', 'no-break space (U+00A0) is mapped to ASCII space'],
+            ["hello\u{3000}world", 'hello world', 'ideographic space (U+3000) is mapped to ASCII space'],
+            ["hello\u{2028}world", 'hello world', 'line separator (U+2028) is mapped to ASCII space'],
+            ["hello\u{2000}world", 'hello world', 'en quad (U+2000) is mapped to ASCII space'],
+        ];
+    }
+
+    public function prohibitedCases(): array
+    {
+        return [
+            // C.2.1 — ASCII control characters
+            'null byte (U+0000)'       => ["pass\x00word"],
+            'unit separator (U+001F)'  => ["pass\x1Fword"],
+            'delete character (U+007F)' => ["pass\x7Fword"],
+
+            // C.2.2 — Non-ASCII control characters (C1 range)
+            'first C1 control (U+0080)' => ["pass\u{0080}word"],
+            'last C1 control (U+009F)'  => ["pass\u{009F}word"],
+
+            // C.3 — Private use characters
+            'first BMP private use (U+E000)' => ["pass\u{E000}word"],
+            'last BMP private use (U+F8FF)'  => ["pass\u{F8FF}word"],
+
+            // C.4 — Non-character code points
+            'first non-character in FDD0-FDEF block (U+FDD0)' => ["pass\u{FDD0}word"],
+            'non-character U+FFFE'                             => ["pass\u{FFFE}word"],
+            'non-character U+FFFF'                             => ["pass\u{FFFF}word"],
+
+            // C.6 — Inappropriate for plain text
+            'interlinear annotation anchor (U+FFF9)' => ["pass\u{FFF9}word"],
+            'replacement character (U+FFFD)'         => ["pass\u{FFFD}word"],
+
+            // C.7 — Inappropriate for canonical representation
+            'ideographic description character left-to-right (U+2FF0)' => ["pass\u{2FF0}word"],
+
+            // C.8 — Change display properties or deprecated
+            'left-to-right mark (U+200E)'    => ["pass\u{200E}word"],
+            'right-to-left mark (U+200F)'    => ["pass\u{200F}word"],
+            'left-to-right override (U+202D)' => ["pass\u{202D}word"],
+
+            // C.9 — Tagging characters
+            'tag space (U+E0020)' => ["pass\u{E0020}word"],
+        ];
+    }
+}

--- a/tests/unit/FreeDSx/Sasl/SaslTest.php
+++ b/tests/unit/FreeDSx/Sasl/SaslTest.php
@@ -46,7 +46,7 @@ class SaslTest extends TestCase
         $this->assertArrayHasKey('CRAM-MD5', $mechs);
         $this->assertArrayHasKey('PLAIN', $mechs);
         $this->assertArrayHasKey('ANONYMOUS', $mechs);
-        $this->assertCount(4, $mechs);
+        $this->assertCount(16, $mechs);
     }
 
     public function testRemove()


### PR DESCRIPTION
Adding SCRAM support since DIGEST-MD5 is long since dead / unsupported. Adding SASL support server side to the LDAP library. But is also nice to support this from the client side.

Additionally adding some markdown doc.